### PR TITLE
Fix PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,5 +2,5 @@ Make sure all of these are checked before submitting a PR! Thank you.
 
 - [ ] I added the project **at the top** of the relevant list (don't add it to the bottom!)
 - [ ] Project is at least 30 days old
-- [ ] Links to the GitHub repo, not npmjs.org
+- [ ] Links to the GitHub repo, not npmjs.com
 - [ ] I've read [CONTRIBUTING.md](/contributing.md)


### PR DESCRIPTION
Fixes `npmjs.org` in PR template -- the correct url is `npmjs.com`.

Make sure all of these are checked before submitting a PR! Thank you.

- [ ] I added the project **at the top** of the relevant list (don't add it to the bottom!)
- [ ] Project is at least 30 days old
- [ ] Links to the GitHub repo, not npmjs.org
- [x] I've read [CONTRIBUTING.md](/contributing.md)
