### PR TITLE
Add styled-icons library

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 ### Built with styled-components
 
 #### Components
+* [styled-icons](https://github.com/jacobwgillespie/styled-icons) - Icons from popular icon packs (Font Awesome, Material, Octicons, etc).
 * [react-microlink](https://github.com/microlinkhq/sdk) - Convert your links into beautiful previews.
 * [react-super-styled](https://github.com/moarwick/react-super-styled) - Build responsive, semantic layouts fast with this design-agnostic toolkit.
 * [reas](https://github.com/diegohaz/reas) - Minimalist and highly customizable UI toolkit.


### PR DESCRIPTION
This PR adds [styled-icons](https://github.com/jacobwgillespie/styled-icons) ([icon explorer](https://styled-icons.js.org/)) to the Components section.  :tada:

---

- [x] I added the project **at the top** of the relevant list (don't add it to the bottom!)
- [x] Project is at least 30 days old
- [x] Links to the GitHub repo, not npmjs.com
- [x] I've read [CONTRIBUTING.md](/contributing.md)
