### PR TITLE
Add styled-normalize

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@
 * [Rebass Grid](https://github.com/rebassjs/grid) - Responsive React grid system built with styled-system.
 
 #### Helpers
+* [styled-normalize](https://github.com/sergeysova/styled-normalize) - Add normalize.css with one line
 * [styled-email-components](https://github.com/sergeybekrin/styled-email-components) - Extension for building email-first components via inline styles.
 * [styled-breakpoints](https://github.com/maxinakenty/styled-breakpoints) - :fire: Simple and powerfull custom breakpoints :fire:
 * [styled-reboot](https://github.com/alexruzzarin/styled-reboot) - Bootstrap v4 reboot.css


### PR DESCRIPTION
[styled-normalize](https://github.com/sergeysova/styled-normalize) allows to import normalize.css just with one line, without any webpack loaders.

### `styled-components@v4`

```jsx
import { Normalize } from 'styled-normalize'

export const App = () => (
	<div>
		<Normalize />
	</div>
)
```


### `styled-components@v3`

```js
import { injectGlobal } from 'styled-components'
import { normalize } from 'styled-normalize'

injectGlobal`
	${normalize}
`
```