### PR TITLE
Adding styless to helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@
 * [Rebass Grid](https://github.com/rebassjs/grid) - Responsive React grid system built with styled-system.
 
 #### Helpers
+* [styless](https://github.com/jean343/styless) - Style your components declaratively with familiar less syntax.
 * [styled-px2vw](https://github.com/hnzycfcfed/styled-px2vw) - Extension of styled-components with features for convert px to vw units.
 * [styled-normalize](https://github.com/sergeysova/styled-normalize) - Add normalize.css with one line
 * [styled-email-components](https://github.com/sergeybekrin/styled-email-components) - Extension for building email-first components via inline styles.


### PR DESCRIPTION
Make sure all of these are checked before submitting a PR! Thank you.

- [x] I added the project **at the top** of the relevant list (don't add it to the bottom!)
- [x] Project is at least 30 days old
- [x] Links to the GitHub repo, not npmjs.com
- [x] I've read [CONTRIBUTING.md](/contributing.md)

I do believe that this contribution may be controversial as highlighted in: [1747](https://github.com/styled-components/styled-components/issues/1747).
The main difference is that `styless` is using the actual `less` compiler to parse the input and generate `styled-components` compatible code. It uses the `less plugins` to convert the code of interest, it has minimal string transformation.
This transformation is done at compile time in a babel plugin and should not impact the run time. Additionally, auto-prefixing is done in less, and it is using less of `styled-components`.

My motivation for creating this plugin is that it makes a much better development experience.
It has a preview of the colour on the left as well as autocomplete. It supports `darken`, `contrast`, etc.
![image](https://user-images.githubusercontent.com/7070881/48290066-9e04fe00-e43f-11e8-93f3-7bcfae29613f.png)

I did read about the [future](https://medium.com/styled-components/with-styled-components-into-the-future-d1d917e7c22c) of styled components, and while it does not align with the vision, it does bring many aspects today.

I am looking for feedback, and let me know kindly if you think this is divergent from the SC vision.

Regards,
JP