### PR TITLE
Add react-native-cinch-layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@
 * [styled-components-grid](https://github.com/jameslnewell/styled-components-grid) - Responsive grid components.
 * [Hedron](http://github.com/jsbros/hedron) - No-frills flex-box grid system.
 * [Rebass Grid](https://github.com/rebassjs/grid) - Responsive React grid system built with styled-system.
+* [Cinch Layout](https://github.com/jim-at-jibba/react-native-cinch-layout) - React Native grid system inspired by Hedron.
 
 #### Helpers
 * [styled-media-helper](https://github.com/dvpnt/styled-media-helper) - Makes easy to write media queries using styled-components.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
 * [animated-styled-component](https://github.com/alexvcasillas/animated-styled-components) - React Animated Styled Components.
 
 #### Grid Systems
+* [Cinch Layout](https://github.com/jim-at-jibba/react-native-cinch-layout) - React Native grid system inspired by Hedron.
 * [react-awesome-styled-grid](https://github.com/santosfrancisco/react-awesome-styled-grid) - Responsive grid system layout for React.
 * [react-rasta](https://github.com/chillicream/react-rasta) - Responsive 12 column grid system which comes with a clean and simple API plus tons of feature -- customizable breakpoints, full screen mode, and no gutter to name a few.
 * [styled-grid-responsive](https://github.com/arovillard/styled-grid-responsive) - Responsive, fluid, deeply nestable, non-flexbox grid system with default or custom breakpoints.
@@ -99,7 +100,6 @@
 * [styled-components-grid](https://github.com/jameslnewell/styled-components-grid) - Responsive grid components.
 * [Hedron](http://github.com/jsbros/hedron) - No-frills flex-box grid system.
 * [Rebass Grid](https://github.com/rebassjs/grid) - Responsive React grid system built with styled-system.
-* [Cinch Layout](https://github.com/jim-at-jibba/react-native-cinch-layout) - React Native grid system inspired by Hedron.
 
 #### Helpers
 * [styled-media-helper](https://github.com/dvpnt/styled-media-helper) - Makes easy to write media queries using styled-components.


### PR DESCRIPTION
There are currently not React Native grid systems include. This package makes grid easy in RN.
[Cinch Layout](https://github.com/jim-at-jibba/react-native-cinch-layout)

- [x] I added the project **at the top** of the relevant list (don't add it to the bottom!)
- [x] Project is at least 30 days old
- [x] Links to the GitHub repo, not npmjs.com
- [x] I've read [CONTRIBUTING.md](/contributing.md)
