### PR TITLE
Add Sweetgreen to real apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@
 
 ---
 ### Real Apps
+* [Sweetgreen Android App](https://www.sweetgreen.com/) - Sweetgreen is an American fast casual restaurant chain that serves salads. It already using Styled Components for the React Native Android Application.
 * [WebGazer](https://www.webgazer.io) - Uptime monitoring and analytics service.
 * [Cloverleaf](https://cloverleaf.me/) - Reveal insights on your team's hidden qualities.
 * [Moleskine](https://moleskinestudio.com/) - Moleskine Digital Studio.
@@ -197,6 +198,7 @@
 * [sachagreif.com](http://sachagreif.com) - Personal homepage built with [Gatsby](https://github.com/gatsbyjs/gatsby) ([source](https://github.com/SachaG/sg2017)).
 * [spaceexperience.club](https://spaceexperience.club/) - Brings you each day a stunning picture of our universe, Astronomy Picture of the Day. ([source](https://github.com/caspg/space-exp)).
 * [PostCSS.parts](http://postcss.parts) - Searchable catalog of PostCSS plugins.
+
 ---
 ### Further Reading
 


### PR DESCRIPTION
We are already using Styled Components for all the UI. It has been a really nice approach for the last version, check it here: https://play.google.com/store/apps/details?id=com.sweetgreen.android.app&hl=en

- [x] I added the project **at the top** of the relevant list (don't add it to the bottom!)
- [x] Project is at least 30 days old
- [ ] Links to the GitHub repo, not npmjs.com
- [x] I've read [CONTRIBUTING.md](/contributing.md)
