### PR TITLE
Add nulogy components to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 
 #### Components
 
+* [Nulogy Components](https://github.com/nulogy/design-system/tree/master/components) - Component library of Nulogy Design System built by and for [Nulogy](https://nulogy.com).
 * [styled-off-canvas](https://github.com/marco-streng/styled-off-canvas) - Simple off canvas menu
 * [React95](https://github.com/arturbien/React95) - Windows 95 style UI components for your React app.
 * [react-functional-select](https://github.com/based-ghost/react-functional-select) - Micro-sized & micro-optimized select component for React.js.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@
 
 #### Components
 
-* [Nulogy Components](https://github.com/nulogy/design-system/tree/master/components) - Component library of Nulogy Design System built by and for [Nulogy](https://nulogy.com).
 * [styled-off-canvas](https://github.com/marco-streng/styled-off-canvas) - Simple off canvas menu
 * [React95](https://github.com/arturbien/React95) - Windows 95 style UI components for your React app.
 * [react-functional-select](https://github.com/based-ghost/react-functional-select) - Micro-sized & micro-optimized select component for React.js.
@@ -163,6 +162,7 @@
 
 ---
 ### Real Apps
+* [Nulogy](https://nulogy.com) - Supply chain management software built with open-source [Nulogy Components](https://github.com/nulogy/design-system/tree/master/components).
 * [Taskade](https://taskade.com/) - The unified workspace for distributed teams. Real-time collaboration and organization tool.
 * [njt.now.sh](https://njt.now.sh) - `njt` (npm jump to) 🐸 is a tool and a service that provides package navigation shortcuts. It uses Next.js and involves server-side-rendering ([source](https://github.com/kachkaev/njt)).
 * [Strapi Admin Panel](https://github.com/strapi/strapi/tree/master/packages/strapi-admin) - Strapi built-in admin panel to build content APIs.


### PR DESCRIPTION
[Nulogy Components](https://github.com/nulogy/design-system/tree/master/components) is a collection of components that are part of the Nulogy Design System. The library heavily leverages styled-components to allow for clean css and controlled customization of components. 

Make sure all of these are checked before submitting a PR! Thank you.

- [x] I added the project **at the top** of the relevant list (don't add it to the bottom!)
- [x] Project is at least 30 days old
- [x] Links to the GitHub repo, not npmjs.com
- [x] I've read [CONTRIBUTING.md](/contributing.md)
